### PR TITLE
Reverted default behaviour of Init command - bare=false.

### DIFF
--- a/src/PHPGit/Command/InitCommand.php
+++ b/src/PHPGit/Command/InitCommand.php
@@ -58,6 +58,6 @@ class InitCommand extends Command
     {
         $resolver
             ->setDefault('shared', false)
-            ->setDefault('bare', true);
+            ->setDefault('bare', false);
     }
 }


### PR DESCRIPTION
Since [that change](https://github.com/combro2k/PHPGit/commit/dccfbbbc2c764d963800a17a112a9320a2b277c5#diff-7a7df9b1e097e94409b5a68bc1cd8fba) all PhpUnit tests has become broken as new repositories are marked as bare (meaning: they don't have their working tree checked out). This bugfix reverts that.

Example error message was:

```
1) AddCommandTest::testAdd
PHPGit\Exception\GitException: fatal: This operation must be run in a work tree
```

Related sources:
http://git-scm.com/docs/git-init
http://www.saintsjd.com/2011/01/what-is-a-bare-git-repository/
